### PR TITLE
fix destroy watchedEditors before editor

### DIFF
--- a/lib/line-diff-count-view.js
+++ b/lib/line-diff-count-view.js
@@ -25,7 +25,9 @@ export default class LineDiffCountView {
     if (this.watchedEditors.has(editor)) return;
     this.watchedEditors.add(editor);
     editor.onDidDestroy(() => {
-      this.watchedEditors.delete(editor);
+      if (this.watchedEditors) {
+        this.watchedEditors.delete(editor);
+      }
     });
 
     this.subscriptions.add(editor.onDidSave((event) => {


### PR DESCRIPTION
When atom is restarted `this.watchedEditors` is set to null in `destroy()` before the editor is destroyed